### PR TITLE
Support for PHP 8.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,7 @@
 		"issues": "https://github.com/kdyby/translation/issues"
 	},
 	"require": {
-		"php": ">=7.1",
-		"kdyby/strict-objects": "^2.0",
+		"php": "^8.0",
 		"latte/latte": "^2.5.2 || ^3.0",
 		"nette/caching": "^3.0",
 		"nette/di": "^3.0",
@@ -44,8 +43,7 @@
 		"nette/bootstrap": "^3.0",
 		"nette/forms": "^3.0",
 		"tracy/tracy": "^2.7 || ^3.0",
-		"kdyby/console": "^2.7.1@dev",
-		"kdyby/monolog": "^2.0",
+		"kdyby/console": "^v4.0.0",
 		"symfony/yaml": "^3.4 || ^4.0",
 		"symfony/console": "^3.4 || ^4.0",
 		"nette/tester": "^2.2",

--- a/src/CatalogueCompiler.php
+++ b/src/CatalogueCompiler.php
@@ -19,9 +19,6 @@ use Nette\PhpGenerator\PhpLiteral;
 
 class CatalogueCompiler
 {
-
-	use \Kdyby\StrictObjects\Scream;
-
 	/**
 	 * @var \Nette\Caching\Cache
 	 */

--- a/src/CatalogueFactory.php
+++ b/src/CatalogueFactory.php
@@ -14,9 +14,6 @@ use Kdyby;
 
 class CatalogueFactory
 {
-
-	use \Kdyby\StrictObjects\Scream;
-
 	/**
 	 * @var \Kdyby\Translation\FallbackResolver
 	 */

--- a/src/Console/ExtractCommand.php
+++ b/src/Console/ExtractCommand.php
@@ -21,7 +21,6 @@ use Symfony\Component\Translation\Writer\TranslationWriter;
 class ExtractCommand extends \Symfony\Component\Console\Command\Command
 {
 
-	use \Kdyby\StrictObjects\Scream;
 
 	/**
 	 * @var string

--- a/src/DI/TranslationExtension.php
+++ b/src/DI/TranslationExtension.php
@@ -390,12 +390,6 @@ class TranslationExtension extends \Nette\DI\CompilerExtension
 
 		if ($config['logging'] === TRUE) {
 			$translator->addSetup('injectPsrLogger');
-
-		//} elseif (is_string($config['logging'])) { // channel for kdyby/monolog
-		//	$translator->addSetup('injectPsrLogger', [
-		//		new Statement(sprintf('@%s::channel', KdybyLogger::class), [$config['logging']]),
-		//	]);
-
 		} elseif ($config['logging'] !== NULL) {
 			throw new \Kdyby\Translation\InvalidArgumentException(sprintf(
 				'Invalid config option for logger. Valid are TRUE for general psr/log or string for kdyby/monolog channel, but %s was given',

--- a/src/DI/TranslationExtension.php
+++ b/src/DI/TranslationExtension.php
@@ -12,7 +12,6 @@ namespace Kdyby\Translation\DI;
 
 use Closure;
 use Kdyby\Console\DI\ConsoleExtension;
-use Kdyby\Monolog\Logger as KdybyLogger;
 use Kdyby\Translation\Caching\PhpFileStorage;
 use Kdyby\Translation\CatalogueCompiler;
 use Kdyby\Translation\CatalogueFactory;
@@ -58,7 +57,7 @@ use Tracy\IBarPanel;
 class TranslationExtension extends \Nette\DI\CompilerExtension
 {
 
-	use \Kdyby\StrictObjects\Scream;
+
 
 	/** @deprecated */
 	const LOADER_TAG = self::TAG_LOADER;
@@ -392,10 +391,10 @@ class TranslationExtension extends \Nette\DI\CompilerExtension
 		if ($config['logging'] === TRUE) {
 			$translator->addSetup('injectPsrLogger');
 
-		} elseif (is_string($config['logging'])) { // channel for kdyby/monolog
-			$translator->addSetup('injectPsrLogger', [
-				new Statement(sprintf('@%s::channel', KdybyLogger::class), [$config['logging']]),
-			]);
+		//} elseif (is_string($config['logging'])) { // channel for kdyby/monolog
+		//	$translator->addSetup('injectPsrLogger', [
+		//		new Statement(sprintf('@%s::channel', KdybyLogger::class), [$config['logging']]),
+		//	]);
 
 		} elseif ($config['logging'] !== NULL) {
 			throw new \Kdyby\Translation\InvalidArgumentException(sprintf(

--- a/src/Diagnostics/Panel.php
+++ b/src/Diagnostics/Panel.php
@@ -25,7 +25,6 @@ use Tracy\Helpers;
 class Panel implements \Tracy\IBarPanel
 {
 
-	use \Kdyby\StrictObjects\Scream;
 
 	/**
 	 * @var \Kdyby\Translation\Translator

--- a/src/Dumper/NeonFileDumper.php
+++ b/src/Dumper/NeonFileDumper.php
@@ -19,7 +19,6 @@ use Symfony\Component\Translation\MessageCatalogue;
 class NeonFileDumper extends \Symfony\Component\Translation\Dumper\FileDumper
 {
 
-	use \Kdyby\StrictObjects\Scream;
 
 	/**
 	 * {@inheritDoc}

--- a/src/Extractors/LatteExtractor.php
+++ b/src/Extractors/LatteExtractor.php
@@ -19,7 +19,6 @@ use Symfony\Component\Translation\MessageCatalogue;
 class LatteExtractor implements \Symfony\Component\Translation\Extractor\ExtractorInterface
 {
 
-	use \Kdyby\StrictObjects\Scream;
 
 	/**
 	 * @var string

--- a/src/FallbackResolver.php
+++ b/src/FallbackResolver.php
@@ -12,9 +12,6 @@ namespace Kdyby\Translation;
 
 class FallbackResolver
 {
-
-	use \Kdyby\StrictObjects\Scream;
-
 	/**
 	 * @var array
 	 */

--- a/src/Latte/TranslateMacros.php
+++ b/src/Latte/TranslateMacros.php
@@ -19,7 +19,6 @@ use Latte\PhpWriter;
 class TranslateMacros extends \Latte\Macros\MacroSet
 {
 
-	use \Kdyby\StrictObjects\Scream;
 
 	public static function install(Compiler $compiler)
 	{

--- a/src/LocaleResolver/AcceptHeaderResolver.php
+++ b/src/LocaleResolver/AcceptHeaderResolver.php
@@ -16,8 +16,6 @@ use Nette\Http\IRequest;
 class AcceptHeaderResolver implements \Kdyby\Translation\IUserLocaleResolver
 {
 
-	use \Kdyby\StrictObjects\Scream;
-
 	const ACCEPT_LANGUAGE_HEADER = 'Accept-Language';
 
 	/**

--- a/src/LocaleResolver/ChainResolver.php
+++ b/src/LocaleResolver/ChainResolver.php
@@ -16,7 +16,7 @@ use Kdyby\Translation\Translator;
 class ChainResolver implements \Kdyby\Translation\IUserLocaleResolver
 {
 
-	use \Kdyby\StrictObjects\Scream;
+
 
 	/**
 	 * @var array|\Kdyby\Translation\IUserLocaleResolver[]

--- a/src/LocaleResolver/LocaleParamResolver.php
+++ b/src/LocaleResolver/LocaleParamResolver.php
@@ -17,8 +17,6 @@ use Nette\Application\Request;
 class LocaleParamResolver implements \Kdyby\Translation\IUserLocaleResolver
 {
 
-	use \Kdyby\StrictObjects\Scream;
-
 	/**
 	 * @var \Nette\Application\Request
 	 */

--- a/src/LocaleResolver/SessionResolver.php
+++ b/src/LocaleResolver/SessionResolver.php
@@ -28,8 +28,6 @@ use Nette\Http\Session;
 class SessionResolver implements \Kdyby\Translation\IUserLocaleResolver
 {
 
-	use \Kdyby\StrictObjects\Scream;
-
 	/**
 	 * @var \Nette\Http\SessionSection|\stdClass
 	 */

--- a/src/MessageCatalogue.php
+++ b/src/MessageCatalogue.php
@@ -13,8 +13,6 @@ namespace Kdyby\Translation;
 class MessageCatalogue extends \Symfony\Component\Translation\MessageCatalogue
 {
 
-	use \Kdyby\StrictObjects\Scream;
-
 	/**
 	 * {@inheritdoc}
 	 */

--- a/src/Phrase.php
+++ b/src/Phrase.php
@@ -16,8 +16,6 @@ namespace Kdyby\Translation;
 class Phrase
 {
 
-	use \Kdyby\StrictObjects\Scream;
-
 	/**
 	 * @var string
 	 */

--- a/src/PrefixedTranslator.php
+++ b/src/PrefixedTranslator.php
@@ -16,8 +16,6 @@ use Nette\Utils\Strings;
 class PrefixedTranslator implements \Kdyby\Translation\ITranslator
 {
 
-	use \Kdyby\StrictObjects\Scream;
-
 	/**
 	 * @var \Kdyby\Translation\ITranslator|\Kdyby\Translation\Translator|\Kdyby\Translation\PrefixedTranslator
 	 */

--- a/src/TemplateHelpers.php
+++ b/src/TemplateHelpers.php
@@ -15,9 +15,6 @@ use Latte\Runtime\FilterInfo;
 
 class TemplateHelpers
 {
-
-	use \Kdyby\StrictObjects\Scream;
-
 	/**
 	 * @var \Kdyby\Translation\ITranslator|\Kdyby\Translation\Translator|\Kdyby\Translation\PrefixedTranslator
 	 */

--- a/src/TranslationLoader.php
+++ b/src/TranslationLoader.php
@@ -20,9 +20,6 @@ use Symfony\Component\Translation\MessageCatalogue;
  */
 class TranslationLoader implements \Kdyby\Translation\IResourceLoader
 {
-
-	use \Kdyby\StrictObjects\Scream;
-
 	/**
 	 * Loaders used for import.
 	 *

--- a/src/Translator.php
+++ b/src/Translator.php
@@ -22,8 +22,6 @@ use Symfony\Component\Translation\Loader\LoaderInterface;
 class Translator extends \Symfony\Component\Translation\Translator implements \Kdyby\Translation\ITranslator
 {
 
-	use \Kdyby\StrictObjects\Scream;
-
 	/**
 	 * @var \Kdyby\Translation\IUserLocaleResolver
 	 */


### PR DESCRIPTION
Dropped support of kdyby/monolog logger, and Kdyby\StrictObjects since they do not support PHP 8.0 in available versions